### PR TITLE
Revert "ERSSUP-63296 - sandbox-docker(deps): bump node from 16.14.2-alpine to 18.7.0-alpine in /sandbox"

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.7.0-alpine
+FROM node:16.14.2-alpine
 
 COPY . /sandbox
 


### PR DESCRIPTION
Reverts NHSDigital/e-referrals-service-patient-care-api#69

Sandbox failing to build with this version of node